### PR TITLE
match preceding \n if exists

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   commentsyntax
 author Satoshi Sahara
 email  <sahara.satoshi@gmail.com>
-date   2018-04-30
+date   2018-06-12
 name   Comment Syntax support
 desc   Allow to use source comment syntax to leave edit instructions of the page. Comments are visible only in the source view, not rendered as any page elements.
 url    https://www.dokuwiki.org/plugin:commentsyntax

--- a/syntax/cstyle.php
+++ b/syntax/cstyle.php
@@ -20,7 +20,7 @@ class syntax_plugin_commentsyntax_cstyle extends DokuWiki_Syntax_Plugin {
 
     protected $mode;
     protected $pattern = array(
-            1 => '/\*(?=.*?\*/)',
+            1 => '[ \t]*\n?/\*(?=.*?\*/)',
             4 => '\*/',
     );
 


### PR DESCRIPTION
remove whole comment lines from wiki source text. The LF (\n) which appears after the exit pattern `*/` will work in stead of the eaten LF by the entry pattern.