### PR TITLE
remove "<" and ">"

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,6 +1,6 @@
 base   commentsyntax
 author Satoshi Sahara
-email  <sahara.satoshi@gmail.com>
+email  sahara.satoshi@gmail.com
 date   2022-01-01
 name   Comment Syntax support
 desc   Allow to use source comment syntax to leave edit instructions of the page. Comments are visible only in the source view, not rendered as any page elements.


### PR DESCRIPTION
remove "<" and ">" to make mailto link created by ~~INFO:syntaxplugins~~ (as used on wiki:syntax page) valid, currently the link is &lt;sahara.satoshi@gmail.com&gt;