### PR TITLE
Added a config-urable option to strip out the html comments from the generated page.

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -8,3 +8,4 @@ $conf['toolbar_button']     = 0; // default off
 $conf['use_cstyle_nest']    = 0;
 $conf['use_oneline_style']  = 0;
 $conf['log_invalid_macro']  = 0;
+$conf['striphtmlcomments']  = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -8,3 +8,4 @@ $meta['toolbar_button']     = array('onoff');
 $meta['use_cstyle_nest']    = array('onoff');
 $meta['use_oneline_style']  = array('onoff');
 $meta['log_invalid_macro']  = array('onoff');
+$meta['striphtmlcomments']  = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -10,3 +10,4 @@ $lang['use_cstyle_nest']    = 'use nested C-style comments syntax';
 $lang['use_oneline_style']  = 'use one-line style comments syntax //<br>'
                              .'(note: this may interfere with the markup for italics)';
 $lang['log_invalid_macro']  = 'record invalid macro directives in PHP error log: '.hsc(ini_get('error_log'));
+$lang['striphtmlcomments']  = 'remove the html comments from the generated HTML output (so that page source will not show those comments)';

--- a/syntax/htmlcomment.php
+++ b/syntax/htmlcomment.php
@@ -65,7 +65,7 @@ class syntax_plugin_commentsyntax_htmlcomment extends DokuWiki_Syntax_Plugin
     {
         if ($format == 'xhtml') {
             list($state, $comment) = $data;
-            if ($state == DOKU_LEXER_SPECIAL) {
+            if ($state == DOKU_LEXER_SPECIAL && !$this->getConf('striphtmlcomments')) {
                 $renderer->doc .= '<!--'.$comment.'-->';
             }
             return true;


### PR DESCRIPTION
I wanted the html comments to not be contained in the generated html page. Default stays the same (html comments shown), but with configuration setting, html comments can be turned off.